### PR TITLE
Calculate daily SPR mined using blockreward

### DIFF
--- a/advanced_calculator.py
+++ b/advanced_calculator.py
@@ -84,7 +84,7 @@ def calculate_estimated_rewards(network_hashrate, my_hashrate, block_reward, spr
     else:
         my_portion = (my_hashrate * 1e-3) / network_hashrate  # Convert my_hashrate from KH/s to MH/s for comparison
 
-    daily_network_reward = 1015200  # Correct total SPR mined per day
+    daily_network_reward = block_reward * 86400  # Correct total SPR mined per day
     daily_my_reward = daily_network_reward * my_portion
     
     estimated_hourly_spr = daily_my_reward / 24


### PR DESCRIPTION
You are already fetching the blockreward using the `get_block_reward()` function. To simplify the calculation of daily coin emissions, you can directly use the blockreward multiplied by the number of blocks mined per day. blocktime is approximately 1 second, and there are 86400 seconds in a day (60 * 60 * 24), we can estimate around 86400 blocks mined per day.